### PR TITLE
check if textDocument/documentSymbol is supported before using it

### DIFF
--- a/lua/ide/components/outline/component.lua
+++ b/lua/ide/components/outline/component.lua
@@ -180,6 +180,13 @@ OutlineComponent.new = function(name, config)
             return
         end
 
+        local supports_method = #(vim.tbl_filter(function(client)
+          return client.supports_method('textDocument/documentSymbol')
+        end, vim.lsp.buf_get_clients(cur_buf))) > 0
+        if not supports_method then
+            return
+        end
+
         vim.lsp.buf_request_all(cur_buf, 'textDocument/documentSymbol', { textDocument = tdi }, function(resp)
             local result = liblsp.request_all_first_result(resp)
             if result ~= nil then

--- a/lua/ide/components/outline/component.lua
+++ b/lua/ide/components/outline/component.lua
@@ -180,14 +180,16 @@ OutlineComponent.new = function(name, config)
             return
         end
 
+        local lsp_method = 'textDocument/documentSymbol'
+
         local supports_method = #(vim.tbl_filter(function(client)
-          return client.supports_method('textDocument/documentSymbol')
+          return client.supports_method(lsp_method)
         end, vim.lsp.buf_get_clients(cur_buf))) > 0
         if not supports_method then
             return
         end
 
-        vim.lsp.buf_request_all(cur_buf, 'textDocument/documentSymbol', { textDocument = tdi }, function(resp)
+        vim.lsp.buf_request_all(cur_buf, lsp_method, { textDocument = tdi }, function(resp)
             local result = liblsp.request_all_first_result(resp)
             if result ~= nil then
                 _build_outline(result, vim.api.nvim_buf_get_name(cur_buf))


### PR DESCRIPTION
Fixes #9 