### PR TITLE
useability: expose git errors to vim.notify

### DIFF
--- a/lua/ide/lib/async_client.lua
+++ b/lua/ide/lib/async_client.lua
@@ -19,7 +19,7 @@ Client.new = function(cmd)
             -- error reading stdout, capture and return.
             if err then
                 req.error = true
-                req.reason = string.format("error reading from stderr: %s", err)
+                req.reason = string.format("error reading from stdout: %s", err)
                 return
             end
             -- more data to read, concat it to stdout buffer.
@@ -126,7 +126,7 @@ Client.new = function(cmd)
             req.exit_code = exit_code
             if exit_code ~= 0 then
                 req.error = true
-                req.reason = "status code"
+                req.reason = "non-zero status code: " .. exit_code
             end
             req.signal = signal
             vim.schedule(function()

--- a/lua/ide/lib/git/client.lua
+++ b/lua/ide/lib/git/client.lua
@@ -31,10 +31,9 @@ Git.new = function()
     local function handle_req(callback)
         return function(req)
             if req.error then
-                return
-            end
-            if req.exit_code ~= 0 then
-                vim.notify(string.format("git: %s", req.stderr), vim.log.levels.ERROR)
+                vim.notify(string.format("%s\n%s", req.reason, req.stderr),  "error", {
+                    title = "git",
+                })
                 callback(nil)
                 return
             end
@@ -322,7 +321,7 @@ Git.new = function()
         )
     end
 
-    -- List the branches in the current repository. 
+    -- List the branches in the current repository.
     --
     -- @cb  - @function(table|nil), if not nil, a table of branches
     --        The table has the following fields:
@@ -390,7 +389,7 @@ Git.new = function()
 
     -- Return the full sha256 of the current HEAD.
     --
-    -- @cb      - @function(string|nil) - The sha256 of the current head or a 
+    -- @cb      - @function(string|nil) - The sha256 of the current head or a
     --            nil if an error occurred.
     function self.head(cb)
         self.make_request(


### PR DESCRIPTION
this commit fixes the git client such that errors will now be displayed as vim.notify output.

![image](https://user-images.githubusercontent.com/5642902/204641736-7f4485bc-4912-4a5f-b36a-ee2031e9ab35.png)


Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>