### PR TITLE
fix lazy-loading by checking if we're already past the 'VimEnter' event

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,1 @@
+globals = { "vim" }

--- a/lua/ide/workspaces/workspace_controller.lua
+++ b/lua/ide/workspaces/workspace_controller.lua
@@ -266,25 +266,32 @@ function WorkspaceController.new(config)
         -- issues, so do it only after "VimEnter" fires.
         local restore = libwin.restore_cur_win()
         local init_autocmd = nil
-        init_autocmd =  vim.api.nvim_create_autocmd({ "VimEnter" }, {
-            callback = function()
-                -- do not assign if we are git tool.
-                local buf_name = vim.api.nvim_buf_get_name(0)
-                if vim.fn.match(buf_name, ".git/*") >= 0 then
-                    return
-                end
-                -- do not assign if we are a man reader.
-                if vim.fn.match(buf_name, "man://*") >= 0 then
-                    return
-                end
+        local init_callback = function()
+            -- do not assign if we are git tool.
+            local buf_name = vim.api.nvim_buf_get_name(0)
+            if vim.fn.match(buf_name, ".git/*") >= 0 then
+                return
+            end
+            -- do not assign if we are a man reader.
+            if vim.fn.match(buf_name, "man://*") >= 0 then
+                return
+            end
 
-                for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
-                    assign_ws(tab)
-                end
-                restore()
+            for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+                assign_ws(tab)
+            end
+            restore()
+            if init_autocmd then
                 vim.api.nvim_del_autocmd(init_autocmd)
             end
-        })
+        end
+        if vim.v.vim_did_enter then
+            vim.schedule(init_callback)
+        else
+            init_autocmd =  vim.api.nvim_create_autocmd({ "VimEnter" }, {
+                callback = init_callback,
+            })
+        end
 
         self.tabnew_autocmd_id = vim.api.nvim_create_autocmd({ "TabNewEntered" }, {
             callback = self.tabnew_autocmd

--- a/lua/ide/workspaces/workspace_controller.lua
+++ b/lua/ide/workspaces/workspace_controller.lua
@@ -267,13 +267,10 @@ function WorkspaceController.new(config)
         local restore = libwin.restore_cur_win()
         local init_autocmd = nil
         local init_callback = function()
-            -- do not assign if we are git tool.
+            -- do not assign if we are git tool or manpage reader
             local buf_name = vim.api.nvim_buf_get_name(0)
-            if vim.fn.match(buf_name, ".git/*") >= 0 then
-                return
-            end
-            -- do not assign if we are a man reader.
-            if vim.fn.match(buf_name, "man://*") >= 0 then
+            if vim.startswith(buf_name, 'man://') or string.find(buf_name, '%.git/') then
+                log.info('Not assigning workspace, buffer is git tool or manpage reader.')
                 return
             end
 
@@ -286,7 +283,7 @@ function WorkspaceController.new(config)
             end
         end
         if vim.v.vim_did_enter then
-            vim.schedule(init_callback)
+            vim.defer_fn(init_callback, 1)
         else
             init_autocmd =  vim.api.nvim_create_autocmd({ "VimEnter" }, {
                 callback = init_callback,


### PR DESCRIPTION
Fixes #49 

It was checking `VimEnter`, but if we're lazy loading the plugin, the plugin will never see that event because it's already fired by the time the plugin is loaded.