### PR TITLE
Remove auto_close

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ require('ide').setup({
 
     -- workspaces config
     workspaces = {
-        -- automatically close vim if only remaining windows are components
-        auto_close = true,
         -- which panels to open by default, one of: 'left', 'right', 'both', 'none'
         auto_open = 'left',
     }

--- a/doc/nvim-ide.txt
+++ b/doc/nvim-ide.txt
@@ -137,8 +137,6 @@ require('ide').setup({
 
     -- workspaces config
     workspaces = {
-        -- automatically close vim if only remaining windows are components
-        auto_close = true,
         -- which panels to open by default, one of: 'left', 'right', 'both', 'none'
         auto_open = 'left',
     }

--- a/lua/ide/init.lua
+++ b/lua/ide/init.lua
@@ -58,8 +58,6 @@ M.config = {
 
     -- workspaces config
     workspaces = {
-        -- automatically close vim if only remaining windows are components
-        auto_close = true,
         -- which panels to open by default, one of: 'left', 'right', 'both', 'none'
         auto_open = 'left',
     }

--- a/lua/ide/workspaces/workspace_controller.lua
+++ b/lua/ide/workspaces/workspace_controller.lua
@@ -227,26 +227,6 @@ function WorkspaceController.new(config)
         end
     end
 
-    -- Designed to be ran as an autocommand on the "WinEnter" event.
-    --
-    -- Exit's vim if WinEnter was triggered and the only remaining windows are
-    -- component windows.
-    function self.auto_close_autocmd()
-        if not string.find(vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(0)),
-            "component://*") then
-            return
-        end
-
-        for _, v in ipairs(vim.api.nvim_list_wins()) do
-            local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(v))
-            if not string.find(name, "component://*") and name ~= "" then
-                return
-            end
-        end
-
-        vim.cmd("qa")
-    end
-
     -- Initializes and starts the WorkSpace controller.
     --
     -- Once this method exists all existing and new tabs will be assigned
@@ -304,13 +284,6 @@ function WorkspaceController.new(config)
             callback = self.win_history_autocmd
         })
         log.info("WorkspaceController now handling recording viewed window history")
-
-        if self.config.auto_close then
-            self.auto_close_autocmd_id = vim.api.nvim_create_autocmd({ "WinEnter" }, {
-                callback = self.auto_close_autocmd
-            })
-            log.info("WorkspaceController now handling automatic closing of nvim.")
-        end
 
         vim.api.nvim_create_user_command("Workspace", ws_handler, {
             nargs = "*",


### PR DESCRIPTION
Removes auto_close including docs.

Keeps the config being passed in to WorkspaceController.