### PR TITLE
bufferlist: float the current buffer to top of list and track current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Plug 'ldelossa/nvim-ide'
 
 ```lua
 -- default components
+local bufferlist      = require('ide.components.bufferlist')
 local explorer        = require('ide.components.explorer')
 local outline         = require('ide.components.outline')
 local callhierarchy   = require('ide.components.callhierarchy')

--- a/doc/nvim-ide.txt
+++ b/doc/nvim-ide.txt
@@ -375,6 +375,9 @@ Config:
 ```
 {
     default_height = nil,
+    -- float the current buffer to the top of list
+    current_buffer_top = false,
+    -- disable all keymaps
     disabled_keymaps = false,
     keymaps = {
         edit = "<CR>",

--- a/lua/ide/init.lua
+++ b/lua/ide/init.lua
@@ -1,6 +1,6 @@
 -- default components
-local explorer        = require('ide.components.explorer')
 local bufferlist      = require('ide.components.bufferlist')
+local explorer        = require('ide.components.explorer')
 local outline         = require('ide.components.outline')
 local callhierarchy   = require('ide.components.callhierarchy')
 local timeline        = require('ide.components.timeline')

--- a/lua/ide/lib/buf.lua
+++ b/lua/ide/lib/buf.lua
@@ -76,9 +76,13 @@ function Buf.delete_buffer_by_name(name)
     end
 end
 
+function Buf.is_listed_buf(bufnr)
+	return vim.bo[bufnr].buflisted and vim.api.nvim_buf_is_loaded(bufnr) and vim.api.nvim_buf_get_name(bufnr) ~= ""
+end
+
 function Buf.get_listed_bufs()
     return vim.tbl_filter(function(bufnr)
-		return vim.bo[bufnr].buflisted and vim.api.nvim_buf_is_loaded(bufnr) and vim.api.nvim_buf_get_name(bufnr) ~= ""
+        return Buf.is_listed_buf(bufnr)
 	end, vim.api.nvim_list_bufs())
 end
 


### PR DESCRIPTION
Currently there is no indicator in bufferlist of which buffer are you currently in.

This commit floats the current buffer up to the top, and places an asterisk to indicate its the current buffer.

![image](https://user-images.githubusercontent.com/5642902/204957912-931759ff-254b-4987-b7c4-6a2a03193ee7.png)


Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>