### PR TITLE
fix: Bookmarks path error in Windows

### DIFF
--- a/lua/ide/components/bookmarks/component.lua
+++ b/lua/ide/components/bookmarks/component.lua
@@ -7,7 +7,7 @@ local notebook = require('ide.components.bookmarks.notebook')
 
 local BookmarksComponent = {}
 
-BookmarksComponent.NotebooksPath = "~/.config/nvim/bookmarks"
+BookmarksComponent.NotebooksPath = vim.fn.stdpath('config') .. "/bookmarks"
 
 local config_prototype = {
     default_height = nil,


### PR DESCRIPTION
Mentioned in #22 

![image](https://user-images.githubusercontent.com/16725418/205903474-9fdec0e7-959c-45f2-9ded-9aa12b2db470.png)

The NVim default config path in Windows is `~\AppData\Local\nvim`