### PR TITLE
escape dot in regex

### DIFF
--- a/lua/ide/workspaces/workspace_controller.lua
+++ b/lua/ide/workspaces/workspace_controller.lua
@@ -249,7 +249,7 @@ function WorkspaceController.new(config)
         local function init_callback()
             -- do not assign if we are git tool.
             local buf_name = vim.api.nvim_buf_get_name(0)
-            if vim.fn.match(buf_name, ".git/") > -1 then
+            if vim.fn.match(buf_name, "\\.git/") > -1 then
                 return
             end
 


### PR DESCRIPTION
Turns out this escape is needed. It's a Vim regex, but still a regex, where `.` means "any character", meaning that my repo in under `~/git/github/` does not load the plugin because its matching `/git/` when it should only be matching `/.git/`