### PR TITLE
fix,changes: change autocmd events to avoid cursor flashing

### DIFF
--- a/lua/ide/components/changes/component.lua
+++ b/lua/ide/components/changes/component.lua
@@ -368,7 +368,7 @@ ChangesComponent.new = function(name, config)
         return commands.new(self).get()
     end
 
-    vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold" },
+    vim.api.nvim_create_autocmd({ "BufEnter", "TextChanged", "InsertLeave" },
         { callback = self.event_handler })
 
     return self

--- a/lua/ide/components/changes/component.lua
+++ b/lua/ide/components/changes/component.lua
@@ -368,7 +368,7 @@ ChangesComponent.new = function(name, config)
         return commands.new(self).get()
     end
 
-    vim.api.nvim_create_autocmd({ "BufEnter", "TextChanged", "InsertLeave" },
+    vim.api.nvim_create_autocmd({ "BufEnter", "BufWritePost" },
         { callback = self.event_handler })
 
     return self


### PR DESCRIPTION
Fixes #82 

These autocmd events I think accomplish the same thing you were trying to do.