### PR TITLE
feat,explorer: use fs_event_t to display external fs events for open

### DIFF
--- a/lua/ide/panels/panel.lua
+++ b/lua/ide/panels/panel.lua
@@ -196,9 +196,7 @@ Panel.new = function(tab, position, components)
             table.insert(restores, libwin.set_option_with_restore(w, "winfixheight", false))
         end
 
-        -- make a copy of the last layout, we'll use it to determine if we can
-        -- restore dimensions.
-        local old_layout = vim.deepcopy(self.layout)
+        local old_layout = self.layout
 
         -- if all components are hidden, don't open the panel at all.
         local continue = false


### PR DESCRIPTION
In the UI, if a dir is open, register an fs_event_t for it and refresh the UI if external fs events.

Unregister it on dir node collapses.

Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>