### PR TITLE
Only load the components after setup is done to fix icon loading issue

### DIFF
--- a/lua/ide/components/bookmarks/init.lua
+++ b/lua/ide/components/bookmarks/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.bookmarks.component')
 
 local Init = {}
 
-Init.Name = "Bookmarks"
+Init.Name = require('ide').config.default_names.Bookmarks
 
 
 local function register_component()

--- a/lua/ide/components/branches/init.lua
+++ b/lua/ide/components/branches/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.branches.component')
 
 local Init = {}
 
-Init.Name = "Branches"
+Init.Name = require('ide').config.default_names.Branches
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/bufferlist/init.lua
+++ b/lua/ide/components/bufferlist/init.lua
@@ -3,7 +3,7 @@ local component = require("ide.components.bufferlist.component")
 
 local Init = {}
 
-Init.Name = "BufferList"
+Init.Name = require('ide').config.default_names.BufferList
 
 local function register_component()
 	component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/callhierarchy/init.lua
+++ b/lua/ide/components/callhierarchy/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.callhierarchy.component')
 
 local Init = {}
 
-Init.Name = "CallHierarchy"
+Init.Name = require('ide').config.default_names.CallHierarchy
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/changes/init.lua
+++ b/lua/ide/components/changes/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.changes.component')
 
 local Init = {}
 
-Init.Name = "Changes"
+Init.Name = require('ide').config.default_names.Changes
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/commits/init.lua
+++ b/lua/ide/components/commits/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.commits.component')
 
 local Init = {}
 
-Init.Name = "Commits"
+Init.Name = require('ide').config.default_names.Commits
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/explorer/init.lua
+++ b/lua/ide/components/explorer/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.explorer.component')
 
 local Init = {}
 
-Init.Name = "Explorer"
+Init.Name = require('ide').config.default_names.Explorer
 
 local function register_component()
 

--- a/lua/ide/components/outline/init.lua
+++ b/lua/ide/components/outline/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.outline.component')
 
 local Init = {}
 
-Init.Name = "Outline"
+Init.Name = require('ide').config.default_names.Outline
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/terminal/init.lua
+++ b/lua/ide/components/terminal/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.terminal.component')
 
 local Init = {}
 
-Init.Name = "Terminal"
+Init.Name = require('ide').config.default_names.Terminal
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/terminal/terminalbrowser/init.lua
+++ b/lua/ide/components/terminal/terminalbrowser/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.terminal.terminalbrowser.component')
 
 local Init = {}
 
-Init.Name = "TerminalBrowser"
+Init.Name = require('ide').config.default_names.TerminalBrowser
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/components/timeline/init.lua
+++ b/lua/ide/components/timeline/init.lua
@@ -3,7 +3,7 @@ local component = require('ide.components.timeline.component')
 
 local Init = {}
 
-Init.Name = "Timeline"
+Init.Name = require('ide').config.default_names.Timeline
 
 local function register_component()
     component_factory.register(Init.Name, component.new)

--- a/lua/ide/init.lua
+++ b/lua/ide/init.lua
@@ -1,15 +1,16 @@
--- default components
-local bufferlist      = require('ide.components.bufferlist')
-local explorer        = require('ide.components.explorer')
-local outline         = require('ide.components.outline')
-local callhierarchy   = require('ide.components.callhierarchy')
-local timeline        = require('ide.components.timeline')
-local terminal        = require('ide.components.terminal')
-local terminalbrowser = require('ide.components.terminal.terminalbrowser')
-local changes         = require('ide.components.changes')
-local commits         = require('ide.components.commits')
-local branches        = require('ide.components.branches')
-local bookmarks       = require('ide.components.bookmarks')
+local default_names = {
+    BufferList = "BufferList",
+    Explorer = "Explorer",
+    Outline = "Outline",
+    CallHierarchy = "CallHierarchy",
+    Bookmarks = "Bookmarks",
+    TerminalBrowser = "TerminalBrowser",
+    Terminal = "Terminal",
+    Changes = "Changes",
+    Commits = "Commits",
+    Timeline = "Timeline",
+    Branches = "Branches",
+}
 
 local M = {}
 
@@ -21,6 +22,7 @@ local M = {}
 -- Modules can read from this field to get config values. For example
 -- require('ide').config.
 M.config = {
+    default_names = default_names,
     -- The global icon set to use.
     -- values: "nerd", "codicon", "default"
     icon_set = "default",
@@ -51,10 +53,16 @@ M.config = {
     -- panels defined by groups of components, user is free to redefine the defaults
     -- and/or add additional.
     panel_groups = {
-        explorer = { bufferlist.Name, explorer.Name, outline.Name, callhierarchy.Name, bookmarks.Name,
-            terminalbrowser.Name },
-        terminal = { terminal.Name },
-        git = { changes.Name, commits.Name, timeline.Name, branches.Name }
+        explorer = {
+            default_names.BufferList,
+            default_names.Explorer,
+            default_names.Outline,
+            default_names.CallHierarchy,
+            default_names.Bookmarks,
+            default_names.TerminalBrowser,
+        },
+        terminal = { default_names.Terminal },
+        git = { default_names.Changes, default_names.Commits, default_names.Timeline, default_names.Branches },
     },
     -- workspaces config
     workspaces = {
@@ -81,6 +89,18 @@ function M.setup(config)
     if M.config["icon_set"] == "codicon" then
         require('ide.icons').global_icon_set = require('ide.icons.codicon_icon_set').new()
     end
+
+    require("ide.components.bufferlist")
+    require("ide.components.explorer")
+    require("ide.components.outline")
+    require("ide.components.callhierarchy")
+    require("ide.components.timeline")
+    require("ide.components.terminal")
+    require("ide.components.terminal.terminalbrowser")
+    require("ide.components.changes")
+    require("ide.components.commits")
+    require("ide.components.branches")
+    require("ide.components.bookmarks")
 
     -- create and launch a workspace controller.
     local wsctrl = require('ide.workspaces.workspace_controller').new(M.config.workspaces)


### PR DESCRIPTION
Currently, setting the icon_set in setup function does not work,

ide/init.lua
```   
local terminalbrowser = require('ide.components.terminal.terminalbrowser')
...
require('ide').setup({
        -- The global icon set to use.
        -- values: "nerd", "codicon", "default"
        icon_set = "default",
        -- Component specific configurations and default config overrides.
...
```
Since the components are already imported, and the icons are already loaded by the components (as local variable) before setup is even run.

This merge request intends to fix that by putting the names into ide/init.lua, and have the components import the name from there, and finally load the components after necessary steps are done in setup function.