### PR TITLE
Fix when git repo is in detached state

### DIFF
--- a/lua/ide/components/branches/component.lua
+++ b/lua/ide/components/branches/component.lua
@@ -167,7 +167,7 @@ BranchesComponent.new = function(name, config)
                 if branches == nil or #branches == 0 then
                     return
                 end
-                local children = { {} } -- reserve first item for head.
+                local children = {}
                 for _, branch in ipairs(branches) do
                     local node = branchnode.new(branch.sha, branch.branch, branch.is_head)
                     node.remote = branch.remote
@@ -175,11 +175,10 @@ BranchesComponent.new = function(name, config)
                     node.remote_ref = branch.remote_ref
                     node.tracking = branch.tracking
                     if node.is_head then
-                        children[1] = node
-                        goto continue
+                        table.insert(children, 1, node)
+                    else
+                        table.insert(children, node)
                     end
-                    table.insert(children, node)
-                    ::continue::
                 end
                 local root = branchnode.new("", repo, false, 0)
                 self.tree.add_node(root, children)


### PR DESCRIPTION
It fixes

https://github.com/ldelossa/nvim-ide/issues/20

After fixing,
```
ross@ross-comp:~/packer/opt/which-key.nvim$ git checkout HEAD~1
Note: switching to 'HEAD~1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 5ffa07b refactor: removing deprecated health functions (#377)
ross@ross-comp:~/packer/opt/which-key.nvim$ nvim
```
no longer has errors, while the branches still show up correctly.