### PR TITLE
Fix panel size issue

### DIFF
--- a/lua/ide/buffers/doomscrollbuffer.lua
+++ b/lua/ide/buffers/doomscrollbuffer.lua
@@ -56,6 +56,7 @@ DoomScrollBuffer.new = function(on_scroll, buf, listed, scratch, opts)
         function()
             if self.on_scroll_aucmd ~= nil then
                 vim.api.nvim_del_autocmd(self.on_scroll_aucmd)
+                self.on_scroll_aucmd = nil
             end
         end
     )


### PR DESCRIPTION
Here are the changes, and it fixes all the size issues that I have seen,
1. Added winsize_debug logging function to investigate panel size issues (default is off, debug_winsize = false)
2. When component is attached, fix its width if it is left/right. Fix its height if it is top/bottom
3. old_layout needs to do a deep copy to the self.layout (instead of aliasing assignment)
4. self.layout needs to be cleaned before attaching components (I saw like 60s items in it)
5. self.equal needs to put the restore function in reverse to the list, so that their effects are reverted in reversed order (otherwise the state would be incorrect)
6. normalize_panels resized height of bottom panel, even its winfixheight is set to true. Do a resize again after normalizing

Lastly, it also fixes,
1. doomscrollbuffer removes autocmd that has been removed causing error 