### PR TITLE
Fix explorer tree issues

### DIFF
--- a/lua/ide/components/branches/component.lua
+++ b/lua/ide/components/branches/component.lua
@@ -167,7 +167,7 @@ BranchesComponent.new = function(name, config)
                 if branches == nil or #branches == 0 then
                     return
                 end
-                local children = { {} } -- reserve first item for head.
+                local children = {}
                 for _, branch in ipairs(branches) do
                     local node = branchnode.new(branch.sha, branch.branch, branch.is_head)
                     node.remote = branch.remote
@@ -175,11 +175,10 @@ BranchesComponent.new = function(name, config)
                     node.remote_ref = branch.remote_ref
                     node.tracking = branch.tracking
                     if node.is_head then
-                        children[1] = node
-                        goto continue
+                        table.insert(children, 1, node)
+                    else
+                        table.insert(children, node)
                     end
-                    table.insert(children, node)
-                    ::continue::
                 end
                 local root = branchnode.new("", repo, false, 0)
                 self.tree.add_node(root, children)

--- a/lua/ide/components/explorer/component.lua
+++ b/lua/ide/components/explorer/component.lua
@@ -552,14 +552,6 @@ ExplorerComponent.new = function(name, config)
         vim.cmd("edit " .. vim.fn.fnamemodify(fnode.path, ":."))
     end
 
-    local has_substring = function(s, substring)
-        if #s < #substring then
-            return false
-        end
-
-        return string.sub(s, 1, #substring) == substring
-    end
-
     function self.expand_to_file(path)
 
         local dest = vim.fn.fnamemodify(path, ":.")
@@ -577,7 +569,7 @@ ExplorerComponent.new = function(name, config)
 
             local current = vim.fn.fnamemodify(root.path, ":.")
 
-            if has_substring(dest, current) then
+            if vim.fn.strpart(dest, 0, #current) == current then
                 if not self.tree.root.expanded then
                     self.expand(self.tree.root)
                 end


### PR DESCRIPTION
1. The filename is matched as lua string pattern. One issue can be seen by creating a file ".~" in the root as following,
```
test@Ross1P:~/start/nvim-ide$ touch .~
# then launch nvim would show,
Error executing vim.schedule lua callback: ...site/pack/packer/start/nvim-ide/lua/ide/panels/panel.lua:95: Vim(append):Error executing lua callback: Vim:E874: (NFA) Could not pop the stack!
stack traceback:
        [C]: in function 'match'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:570: in function 'recursive_expand'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:563: in function 'recursive_expand'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:598: in function 'expand_to_file'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:627: in function <...start/nvim-ide/lua/ide/components/explorer/component.lua:601>
        [C]: in function 'nvim_win_close'
        ...site/pack/packer/start/nvim-ide/lua/ide/panels/panel.lua:95: in function 'close'
        ...k/packer/start/nvim-ide/lua/ide/workspaces/workspace.lua:158: in function 'init'
        ...art/nvim-ide/lua/ide/workspaces/workspace_controller.lua:169: in function 'assign_ws'
        ...art/nvim-ide/lua/ide/workspaces/workspace_controller.lua:269: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
stack traceback:
        [C]: in function 'nvim_win_close'
        ...site/pack/packer/start/nvim-ide/lua/ide/panels/panel.lua:95: in function 'close'
        ...k/packer/start/nvim-ide/lua/ide/workspaces/workspace.lua:158: in function 'init'
        ...art/nvim-ide/lua/ide/workspaces/workspace_controller.lua:169: in function 'assign_ws'
        ...art/nvim-ide/lua/ide/workspaces/workspace_controller.lua:269: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```
It is probably a bug in neovim, but not using pattern matching would workaround this issue. Matching with pattern would match '.' to any characters, which may create false negative.
2. If the file root is closed, going to a file buffer will generate following errors,
```
Error detected while processing BufEnter Autocommands for "*":
Error executing lua callback: ...start/nvim-ide/lua/ide/components/explorer/component.lua:584: Cursor position outside buffer
stack traceback:
        [C]: in function 'nvim_win_set_cursor'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:584: in function 'recursive_expand'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:563: in function 'recursive_expand'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:598: in function 'expand_to_file'
        ...start/nvim-ide/lua/ide/components/explorer/component.lua:627: in function <...start/nvim-ide/lua/ide/components/explorer/component.lua:601>
```
Just open the tree root if there is a sub-match.
3. The expand_to_file continues to search even when the file is found in the tree. Early termination is added by returning a boolean.
