### PR TITLE
Fix a wrong function call in previous merge

### DIFF
--- a/lua/ide/components/explorer/component.lua
+++ b/lua/ide/components/explorer/component.lua
@@ -571,7 +571,7 @@ ExplorerComponent.new = function(name, config)
 
             if vim.fn.strpart(dest, 0, #current) == current then
                 if not self.tree.root.expanded then
-                    self.expand(self.tree.root)
+                    self.expand(nil, self.tree.root)
                 end
                 -- expanding will set a node's children to collapsed, so only do
                 -- this if the node is not currently expanded, this allows the

--- a/lua/ide/components/explorer/component.lua
+++ b/lua/ide/components/explorer/component.lua
@@ -273,6 +273,7 @@ ExplorerComponent.new = function(name, config)
             return
         end
         self.tree.collapse_subtree(fnode)
+        self.unregister_fsevent(fnode)
         self.tree.marshal({ virt_text_pos = 'right_align' })
         self.state["cursor"].restore()
     end


### PR DESCRIPTION
1. self.expand is called wrongly in previous change
2. expand creates fs_event watch, while it is not removed when collapsing. Remove that. (else, try expanding .git folder and collapse it, while the current file is in another folder. Going to the file would also open the .git folder)