### PR TITLE
Remove duplicate tag

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -6,7 +6,6 @@ ide-callhierarchy-components	nvim-ide.txt	/*ide-callhierarchy-components*
 ide-changes-components	nvim-ide.txt	/*ide-changes-components*
 ide-commits-components	nvim-ide.txt	/*ide-commits-components*
 ide-components	nvim-ide.txt	/*ide-components*
-ide-components	nvim-ide.txt	/*ide-components*
 ide-contents	nvim-ide.txt	/*ide-contents*
 ide-default-components	nvim-ide.txt	/*ide-default-components*
 ide-explorer-components	nvim-ide.txt	/*ide-explorer-components*


### PR DESCRIPTION
Remove the duplicate 'ide-components' tag. Package managers such as lazy.nvim (https://github.com/folke/lazy.nvim) complain about this duplicate tag when the plugin is installed