### PR TITLE
fix(docs): use |link| syntax to link to ide-components tag

### DIFF
--- a/doc/nvim-ide.txt
+++ b/doc/nvim-ide.txt
@@ -161,7 +161,7 @@ definitions of which components make up a panel group.
 As a high level user, you can just assume that each component module will have
 a global "Name" variable to use, `nvim-ide` handles everything else involved in
 displaying a Component plugin. If you are interested in developing out-of-tree
-components, then check out *ide-components* section.
+components, then check out the |ide-components| section.
 
 Once the setup function is called a new 'Workspace' is created for each tab and
 the default panels will be loaded and displayed. By default only the left panel


### PR DESCRIPTION
Hey there, thanks for this sweet plugin!

I'm trying to add it to my nixos config without using Packer, but the `buildVimPlugin` helper that nixpkgs uses chokes with

```
E154: Duplicate tag "ide-components" in file /nix/store/g54plhkm0r8i7lipjvybfq77vcfnc805-vimplugin-nvim-ide/./doc/nvim-ide.txtFailed to build help tags!
```

This seems to be happening because the link to the `ide-components` section is using `*asterisks*` instead of `|pipes|`, so its actually defining the tag instead of linking to it. Or at least, that's what I gather from a quick google - I've never tried writing docs for a vim plugin before.

At any rate, if I point my nix config at the commit from this PR, it stops yelling at me :smile: