### PR TITLE
Sort the windows 

### DIFF
--- a/lua/ide/buffers/diffbuffer.lua
+++ b/lua/ide/buffers/diffbuffer.lua
@@ -41,10 +41,12 @@ DiffBuffer.new = function(path_a, path_b)
 
         -- if no wins, create one
         if #wins == 0 then
+            local cur_win = vim.api.nvim_get_current_win()
             vim.cmd("vsplit")
             -- may inherit the SB win highlight, reset it.
             vim.api.nvim_win_set_option(cur_win, 'winhighlight', 'Normal:Normal')
         else
+            table.sort(wins)
             vim.api.nvim_set_current_win(wins[1])
         end
 


### PR DESCRIPTION
When there are multiple number of windows (non-components), all other will be closed except the first one. However the windows returned from vim.api.nvim_tabpage_list_wins is not in a meaningful order. So the layout of neovim can be messed up after diff is created.

The fix here is to sort the win list, and it is most likely that the windows with the minimum handle value is the main editor (so the splitting should be done there).