### PR TITLE
fix(docs) : Update Module Path in Explorer Presets Documentation

### DIFF
--- a/doc/nvim-ide.txt
+++ b/doc/nvim-ide.txt
@@ -565,7 +565,7 @@ Config:
 <
 
 The following keymapping presets are available in the
-`require('ide.explorer.components.presets')` module:
+`require('ide.components.explorer.presets')` module:
 
 >
 


### PR DESCRIPTION
Presets is located at `lua/ide/components/explorer/presets.lua`. The current docs are having an incorrect path.