### PR TITLE
outline: collapse and expand nodes during source file traversal

### DIFF
--- a/lua/ide/components/changes/component.lua
+++ b/lua/ide/components/changes/component.lua
@@ -506,7 +506,7 @@ ChangesComponent.new = function(name, config)
 
 	vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold" }, {
 		callback = function()
-			if not self.is_displayed then
+			if not self.is_displayed() then
 				return
 			end
 

--- a/lua/ide/components/commits/commitnode.lua
+++ b/lua/ide/components/commits/commitnode.lua
@@ -71,6 +71,11 @@ CommitNode.new = function(sha, file, subject, author, date, tags, depth)
 			end
 
 			local lines = {}
+
+			if self.is_file then
+				table.insert(lines, string.format("%s %s", icons.global_icon_set.get_icon("File"), self.file))
+			end
+
 			table.insert(lines, string.format("%s %s", icons.global_icon_set.get_icon("GitCommit"), commit.sha))
 			if (self.tags) then
 				table.insert(lines, string.format("%s%s", icons.global_icon_set.get_icon("GitCommit"), self.tags))

--- a/lua/ide/components/explorer/component.lua
+++ b/lua/ide/components/explorer/component.lua
@@ -606,7 +606,7 @@ ExplorerComponent.new = function(name, config)
 	end
 
 	function self.expand_to_file_async(root, path)
-		if not self.is_displayed or self.tree == nil then
+		if not self.is_displayed() or self.tree == nil then
 			return
 		end
 

--- a/lua/ide/components/outline/symbolnode.lua
+++ b/lua/ide/components/outline/symbolnode.lua
@@ -24,15 +24,21 @@ SymbolNode.new = function(document_symbol, depth)
 	end
 
 	local key =
-		string.format("%s:%s:%s", document_symbol.name, document_symbol.range["start"], document_symbol.range["end"])
+			string.format("%s:%s:%s", document_symbol.name, document_symbol.range["start"], document_symbol.range["end"])
 	local self = node.new("symbol", document_symbol.name, key, depth)
+
+	if depth == 0 then
+		self.expanded = true
+	else
+		self.expanded = false
+	end
 
 	-- clear the child's field of document_symbol, it'll be duplicate info once
 	-- this node is in a @Tree.
 	local symbol = vim.deepcopy(document_symbol)
 	symbol.children = (function()
-		return {}
-	end)()
+				return {}
+			end)()
 
 	self.document_symbol = symbol
 
@@ -72,7 +78,7 @@ SymbolNode.new = function(document_symbol, depth)
 		end
 		table.insert(lines, string.format(""))
 		if (self.document_symbol.detail ~= nil) then
-					table.insert(lines, string.format("%s", self.document_symbol.detail))
+			table.insert(lines, string.format("%s", self.document_symbol.detail))
 		end
 
 		libpopup.until_cursor_move(lines)

--- a/lua/ide/icons/icon_set.lua
+++ b/lua/ide/icons/icon_set.lua
@@ -106,6 +106,11 @@ IconSet.new = function()
 
 	function self.set_win_highlights()
 		for name, icon in pairs(self.list_icons()) do
+			if name == "IndentGuide" then
+				vim.cmd(string.format("syn match %s /%s/", 'Conceal', icon))
+				goto continue
+			end
+
 			local hi = string.format("%s%s", "TS", name)
 			if vim.fn.hlexists(hi) ~= 0 then
 				vim.cmd(string.format("syn match %s /%s/", hi, icon))


### PR DESCRIPTION
Make the outline collapse automatically once a node is exited, and recursively expand to the current highlighted node. 

This makes big outlines way less noisy and easier to follow. 

A couple other improvements:

- We weren't calling the function to check if a component is visible correctly, and subsequently doing unnecessary work in the background, stop that. 
- Make IndentGuides use Conceal highlight, which reduces the business of most component tree views 